### PR TITLE
Removed hardcoded apiUrl and implemented a temporary solution to keep the feedback working.

### DIFF
--- a/frontend/src/hooks/useFeedback.js
+++ b/frontend/src/hooks/useFeedback.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { feedbackApi } from '../services/feedbackApi';
+import { useSettings } from './useSettings';
 
 // Dedicated feedback hook - easy to replace with your coworker's implementation
 export const useFeedback = () => {
@@ -7,6 +8,7 @@ export const useFeedback = () => {
   const [detailedFeedback, setDetailedFeedback] = useState({});
   const [feedbackSubmitting, setFeedbackSubmitting] = useState({});
   const [closingFeedback, setClosingFeedback] = useState({});
+  const { baseUrl } = useSettings();
 
   // Get feedback configuration
   const config = feedbackApi.getConfig();
@@ -109,7 +111,7 @@ export const useFeedback = () => {
       };
 
       // Submit feedback using the dedicated API service
-      await feedbackApi.submitFeedback(feedbackData);
+      await feedbackApi.submitFeedback(feedbackData, baseUrl);
 
       // Mark as submitted
       setDetailedFeedback(prev => ({

--- a/frontend/src/hooks/useSettings.js
+++ b/frontend/src/hooks/useSettings.js
@@ -3,7 +3,10 @@ import { chatApi } from '../services/chatApi';
 
 export const useSettings = () => {
   const [selectedModel, setSelectedModel] = useState(undefined);
-  const [baseUrl, setBaseUrl] = useState(undefined);
+  const [baseUrl, setBaseUrl] = useState(() => {
+    const saved = localStorage.getItem('baseUrl');
+    return saved || undefined;
+  });
   const [sessionId, setSessionId] = useState(undefined);
   const [sourceUrlInfo, setSourceUrlInfo] = useState({
     exclusionFilters: [],
@@ -16,6 +19,13 @@ export const useSettings = () => {
     const saved = localStorage.getItem('enableSidebarSlider');
     return saved ? JSON.parse(saved) : false;
   });
+
+  // Save baseUrl to localStorage when it changes
+  useEffect(() => {
+    if (baseUrl) {
+      localStorage.setItem('baseUrl', baseUrl);
+    }
+  }, [baseUrl]);
 
   // Fetch web source configuration when baseUrl changes
   useEffect(() => {

--- a/frontend/src/services/feedbackApi.js
+++ b/frontend/src/services/feedbackApi.js
@@ -1,24 +1,26 @@
 // Dedicated feedback API service - easy to replace with your coworker's implementation
 export const feedbackApi = {
   // Submit feedback with fallback to localStorage
-  async submitFeedback(feedbackData) {
+  async submitFeedback(feedbackData, baseUrl) {
     try {
-      // Try to submit to API endpoint
-      const baseUrl = window.location.origin.includes('localhost') 
-        ? 'https://eogeslxp5e.execute-api.us-east-2.amazonaws.com/prod/' 
-        : window.location.origin + '/api/';
+      // Use provided baseUrl if available
+      if (baseUrl) {
+          
+        const response = await fetch(baseUrl + 'feedback', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(feedbackData),
+        });
         
-      const response = await fetch(baseUrl + 'feedback', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(feedbackData),
-      });
-      
-      if (response.ok) {
-        console.log('Feedback submitted successfully:', feedbackData);
-        return { success: true, method: 'api' };
+        if (response.ok) {
+          console.log('Feedback submitted successfully:', feedbackData);
+          return { success: true, method: 'api' };
+        }
+      } else {
+        // Fallback for when baseUrl is not provided
+        console.log('No baseUrl provided, using fallback');
       }
     } catch (apiError) {
       console.log('API not available, logging feedback locally:', feedbackData);


### PR DESCRIPTION
Added baseUrl as a localStorage variable so the feedback function can use for the time being.